### PR TITLE
RestoreDB command fix

### DIFF
--- a/roles/upload_db/tasks/main.yml
+++ b/roles/upload_db/tasks/main.yml
@@ -8,4 +8,4 @@
   copy: src={{ app_name }}.sql dest=/home/deploy/var/www/{{ app_name }}/shared/{{ app_name }}.sql
 
 - name: restore db
-  command: psql {{ app_name }}_production < /home/deploy/var/www/{{ app_name }}/shared/{{ app_name }}.sql -U {{ app_name }}
+  shell: "psql {{ app_name }}_production < /home/deploy/var/www/{{ app_name }}/shared/{{ app_name }}.sql -U {{ app_name }}"


### PR DESCRIPTION
Fix the bug with task "restore db" - when it use directive 'command' I finished up with no tables in db, switched to 'shell'
